### PR TITLE
feat: preserve `multiboot` header in final binary

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -1,0 +1,11 @@
+SECTIONS
+{
+    . = 1M;
+
+    .multiboot : {
+        KEEP(*(.multiboot_header))
+    }
+
+    .text : { *(.text*) }
+}
+

--- a/nedo_os_2/src/boot.rs
+++ b/nedo_os_2/src/boot.rs
@@ -6,22 +6,20 @@ pub struct MultibootHeader {
     pub arch: u32,
     pub length: u32,
     pub checksum: u32,
-    /* optional tags here */ 
+    /* optional tags here */
     pub header_type: u16,
     pub flags: u16,
-    pub size: u32
+    pub size: u32,
 }
 
 #[used]
-#[unsafe(link_section = ".multiboot_header")]
+#[unsafe(link_section = ".multiboot")]
 static MULTIBOOT_HEADER: MultibootHeader = MultibootHeader {
     magic: 0xe85250d6, // multiboot 2
     arch: 0,           // protected mode i386
     length: size_of::<MultibootHeader>() as u32,
-    checksum: (0x100000000 - 
-        (0xe85250d6 + size_of::<MultibootHeader>())) as u32,
+    checksum: (0x100000000 - (0xe85250d6 + size_of::<MultibootHeader>())) as u32,
     header_type: 0,
     flags: 0,
-    size: 8
+    size: 8,
 };
-

--- a/nedo_os_2/targets/x86_64-nedo_os_2.json
+++ b/nedo_os_2/targets/x86_64-nedo_os_2.json
@@ -1,16 +1,19 @@
 {
-    "llvm-target": "x86_64-unknown-none",
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
-    "arch": "x86_64",
-    "target-endian": "little",
-    "target-pointer-width": "64",
-    "target-c-int-width": "32",
-    "os": "none",
-    "executables": true,
-    "linker-flavor": "ld.lld",
-    "linker": "rust-lld",
-    "panic-strategy": "abort",
-    "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float",
-    "rustc-abi": "x86-softfloat"
+	"llvm-target": "x86_64-unknown-none",
+	"data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+	"arch": "x86_64",
+	"target-endian": "little",
+	"target-pointer-width": "64",
+	"target-c-int-width": "32",
+	"os": "none",
+	"executables": true,
+	"linker-flavor": "ld.lld",
+	"linker": "rust-lld",
+	"pre-link-args": {
+		"ld.lld": ["-Tlinker.ld"]
+	},
+	"panic-strategy": "abort",
+	"disable-redzone": true,
+	"features": "-mmx,-sse,+soft-float",
+	"rustc-abi": "x86-softfloat"
 }


### PR DESCRIPTION
Compile your code with `cargo xtask build`, list all headers with `objdump -h ./path/to/nedo_os_2` and happily discover your data inside multiboot header with `objdump -s -j .multiboot ./path/to/nedo_os_2`

<img width="823" alt="Screenshot 2025-05-12 at 23 52 13" src="https://github.com/user-attachments/assets/138286c5-b863-420f-9109-898b10239c83" />

